### PR TITLE
Load custom models on supported frameworks only

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,9 +1,21 @@
-from .base_tf_model import BaseTFModel
-from .base_torch_model import BaseTorchModel
-from .custom_tf_model import CustomTFModel
-from .custom_torch_model import CustomTorchModel
 from ray.rllib.models import ModelCatalog
 
-ModelCatalog.register_custom_model("custom_tf_model", CustomTFModel)
-ModelCatalog.register_custom_model("custom_torch_model", CustomTorchModel)
+from utilities.logger import Logger
 
+logger = Logger(name="RL4CC-Models")
+
+# Try loading the custom models. The user can only have one framework (Torch or
+# Tensorflow) installed.
+try:
+  from .base_torch_model import BaseTorchModel
+  from .custom_torch_model import CustomTorchModel
+  ModelCatalog.register_custom_model("custom_torch_model", CustomTorchModel)
+except ModuleNotFoundError as error:
+  logger.warn(f"Could not register CustomTorchModel: No module named {error.name!r}.")
+
+try:
+  from .base_tf_model import BaseTFModel
+  from .custom_tf_model import CustomTFModel
+  ModelCatalog.register_custom_model("custom_tf_model", CustomTFModel)
+except ModuleNotFoundError as error:
+  logger.warn(f"Could not register CustomTFModel: No module named {error.name!r}.")


### PR DESCRIPTION
An RL4CC user may have either Torch and Tensorflow installed, and possibly not both (as in my case). Currently, the models package automatically registers custom models for both Torch and Tensorflow, resulting in an error if one of the two frameworks is not present. This pull request fixes this by skipping the registration for the unsupported framework. It also prints a similar warning:

```
2024-06-04 12:07:52.613294 [RL4CC-Models] (level 0) WARNING: Could not register CustomTFModel: No module named 'tensorflow'
```