### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig settings for RL4CC.
+#
+# More information on: https://editorconfig.org/
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8


### PR DESCRIPTION
This PR adds a simple `.editorconfig` file to the project's root directory. This file contains some styling settings for programming in Python, such as the number of spaces to use for indentation. I set the values according to the current style (e.g. we use two spaces instead of four).

The `.editorconfig` file is supported by many editors, such as Vim or Visual Studio Code. These editors will automatically read this file and set the configuration without any programmer intervention. So this file helps to contribute to RL4CC because it can automatically enforce the style.

More information about EditorConfig can be found here: https://editorconfig.org/