### PR TITLE
Allow BaseExperiment to accept experiment configuration directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ cython_debug/
 .idea/
 test.py
 
+# Vim swap files.
+*.swp

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ on the [Ray RLLib](https://docs.ray.io/en/latest/rllib/index.html) library.
 
 It includes the following components:
 
-- a simple [`Environment`](environment/base_environment.py) implementation, 
-that should be used as base class when defining more complex problems. It 
-is created by loading the parameters included in the 
-[`env_config.json` file](config_files/README.md#environment-configuration-file).
+- a simple [`Environment`](environment/base_environment.py) implementation, that
+  should be used as a base class when defining more complex problems. It is
+  created by loading the parameters included in the [`env_config`
+  configuration](config_files/README.md#environment-configuration).
 
 - an [`Algorithm`](algorithms/algorithm.py) class, used to define RL 
 algorithms for training/hyperparameter tuning experiments, supported by a 
@@ -44,22 +44,25 @@ sections.
 
 ## How to start a training experiment
 
-To define and start a training experiment exploiting one of the available 
-algorithms:
-1. define the `exp_config.json` file (and, if no previous checkpoint should 
-be considered, the `env_config.json` and `ray_config.json`) as detailed 
-[in the README](config_files/README.md);
-2. initialize a `TrainingExperiment` object by providing the path to the 
-`exp_config.json` file;
+To define and start a training experiment exploiting one of the available algorithms:
+
+1. define the `exp_config` configuration (and, if no previous checkpoint is
+   provided, the `env_config` and `ray_config` configurations) as detailed [in
+   the README](config_files/README.md). These configurations can be defined in
+   Python as dictionaries or using JSON files.
+
+2. initialize a `TrainingExperiment` object by passing the `env_config`
+   configuration or a path to the `exp_config.json` file.
+
 3. call the `TrainingExperiment.run()` method.
 
-Example (when using the pre-defined `BaseEnvironment` and `BaseCallbacks` 
-classes):
+Example using the predefined  `BaseEnvironment` and `BaseCallbacks` classes and
+with a JSON file for `exp_config`:
 
 ```
 from RL4CC.experiments.train import TrainingExperiment
 
-exp = TrainingExperiment("config_files/exp_config.json")
+exp = TrainingExperiment(exp_config_file="config_files/exp_config.json")
 exp.run()
 ```
 
@@ -95,7 +98,7 @@ experiment, your `main.py` file should include:
 import src
 from RL4CC.experiments.train import TrainingExperiment
 
-exp = TrainingExperiment("config_files/exp_config.json")
+exp = TrainingExperiment(exp_config_file="config_files/exp_config.json")
 exp.run()
 ```
 
@@ -133,27 +136,34 @@ experiment, your `main.py` file should include:
 import src
 from RL4CC.experiments.train import TrainingExperiment
 
-exp = TrainingExperiment("config_files/exp_config.json")
+exp = TrainingExperiment(exp_config_file="config_files/exp_config.json")
 exp.run()
 ```
 
 i.e., you must ensure that `src/__init__.py` is actually executed. 
 
-Moreover, the `custom_model` section of the ray_config.json file must be 
-properly defined, as detailed in the corresponding 
+Moreover, the `custom_model` section of the `ray_config` configuration must be
+properly defined, as detailed in the corresponding
 [README](config_files/README.md#how-to-use-custom-policy-models).
 
 ### Expected outputs
 
-The outputs produced during the training experiment are saved in a suitable sub-directory of the `logdir` specified in the 
-[`exp_config.json` file](config_files/README.md#experiment-configuration-file) 
-(or of `~/ray_results` if nothing is provided). These include:
+The outputs produced during the training experiment are saved in a suitable
+sub-directory of the `logdir` specified in the [`exp_config`
+config](config_files/README.md#experiment-configuration) (or in `~/ray_results`
+if nothing is provided). These include:
 
-- `complete_config`: a directory reporting the three configuration files 
-used to define the experiment. Note that, while `env_config.json` and 
-`exp_config.json` are simply copied from the user-specified input directory, 
-the `ray_config.json` file reported here includes also the default values 
-assigned to keys that were not included in the user-defined configuration file.
+- `complete_config`: a directory containing the configuration (`exp_config`,
+  `envconfig` and `ray_config`) used to define the experiment, saved as JSON
+  files.
+> [!NOTE]
+> Two important notes:
+>   - The configuration is saved as files even if you pass to RL4CC dictionaries
+>     and not JSON files.
+>   - While `env_config.json` and `exp_config.json` are simply copied from the
+>     user-defined configurations, the `ray_config.json` file reported here
+>     includes also the default values assigned to keys that were not included
+>     in the user-defined configuration.
 
 - `exp_progress.json`: a file that, during the training, is progressively 
 updated with information related to the last executed iteration, the last 
@@ -161,80 +171,88 @@ saved checkpoint, etc. It also reports the start and end timestamps of the
 experiment, its duration (in seconds) and the average length (in seconds) of 
 each training iteration.
 
-- `checkpoints`: a directory with checkpoints saved according to the frequency 
-specified in the 
-[`exp_config.json` file](config_files/README.md#experiment-configuration-file). 
-Regardless the specified interval, a checkpoint is always saved at the end of 
-the training process.
+- `checkpoints`: a directory with checkpoints saved according to the frequency
+  specified in the [`exp_config`
+  config](config_files/README.md#experiment-configuration). Regardless the
+  specified interval, a checkpoint is always saved at the end of the training
+  process.
 
-- `evaluations.txt`: each row of this file is a dictionary with values 
-collected during the evaluation phase, which runs according 
-to the frequency specified in the 
-[`exp_config.json` file](config_files/README.md#experiment-configuration-file). 
-The dictionary structure follows the one described for the progress.csv file, 
-with an additional field specifying after how many training iterations it has 
-been run.
+- `evaluations.txt`: each row of this file is a dictionary with values collected
+  during the evaluation phase, which runs according to the frequency specified
+  in the [`exp_config` config](config_files/README.md#experiment-configuration).
+  The dictionary structure follows the one described for the progress.csv file,
+  with an additional field specifying after how many training iterations it has
+  been run.
 
-- `figures`: a directory with plots generated during the training, according 
-to the frequency specified in the 
-[`exp_config.json` file](config_files/README.md#experiment-configuration-file).
+- `figures`: a directory with plots generated during the training, according to
+  the frequency specified in the [`exp_config`
+  config](config_files/README.md#experiment-configuration).
 
-- `progress.csv` and/or `result.json`, according to the logging configuration 
-specified in the 
-[`ray_config.json` file](config_files/README.md#ray-algorithm-configuration-file). 
-Each row of these files includes values collected during one 
-training iteration. By default, this will store:
-  - values related to the environment and agent behaviour, as, e.g., the 
-  minimum, maximum and average observed reward, the episode length, the number 
-  of observed episodes, etc.
-  - values related to the Ray cluster status and the resources usage, as, 
-  e.g., the number of healthy workers, the percentage of CPU utilization, the 
-  execution time, etc.
-  - custom values specified by properly implementing the training callbacks 
-  (see, e.g., the provided 
-  [`BaseCallbacks` class](callbacks/base_callbacks.py)).
+- `progress.csv` and/or `result.json`, according to the logging configuration
+  specified in the [`ray_config`
+  config](config_files/README.md#ray-algorithm-configuration). Each row of these
+  files includes values collected during one training iteration. By default,
+  this will store:
+
+  - values related to the environment and agent behaviour, as, e.g., the
+    minimum, maximum and average observed reward, the episode length, the number
+    of observed episodes, etc.
+
+  - values related to the Ray cluster status and the resources usage, as, e.g.,
+    the number of healthy workers, the percentage of CPU utilization, the
+    execution time, etc.
+
+  - custom values specified by properly implementing the training callbacks
+    (see, e.g., the provided [`BaseCallbacks`
+    class](callbacks/base_callbacks.py)).
 
 ## How to start hyperparameter tuning
 
 Hyperparameter Tuning is an integration of the Ray Tune, Air, Rllib libraries.
 
-To define and start a tuning experiment exploiting one of the available 
+To define and start a tuning experiment exploiting one of the available
 algorithms:
-1. define the `tune_config.json` file in the `exp_config.json` file as 
-indicated [in the README](config_files/README.md); note that, since the 
-tuning experiment will run multiple training experiments, also the 
-`env_config.json` and `ray_config.json` files need to be defined as 
-described in the [previous section](#how-to-start-a-training-experiment).
-2. initialize a `TuningExperiment` object by providing the path to the 
-`exp_config.json` file;
-3. call the `TrainingExperiment.run()` method.
-  - Note that, since Air's RunConfig is used on top of the algorithm object, 
-  the user can provide a list of callbacks (classes) as parameters to the run 
-  method, overwriting any previous callbacks indicated.
 
-Example (when using the pre-defined `BaseEnvironment` and, possibly, custom 
-callbacks classes):
+1. define the `tune_config` configuration in the `exp_config` configuration as
+   indicated [in the README](config_files/README.md); note that, since the
+   tuning experiment will run multiple training experiments, also the
+   `env_config` and `ray_config` configurations need to be defined as described
+   in the [previous section](#how-to-start-a-training-experiment). You can
+   define `tune_config` as a dictionary or create a JSON file like
+   `tune_config.json`.
+
+2. initialize a `TuningExperiment` object by providing the `exp_config`
+   configuration, as a dictionary or as a path to an `exp_config.json` file.
+
+3. call the `TrainingExperiment.run()` method.
+  > [!NOTE]
+  > Note that, since Air's RunConfig is used on top of the algorithm object, the
+  > user can provide a list of callbacks (classes) as parameters to the run
+  > method, overwriting any previous callbacks indicated.
+
+Example when using the predefined `BaseEnvironment`, a `exp_config` given as
+file and, possibly, custom callbacks classes:
 
 ```
 from RL4CC.experiments.tune import TuningExperiment
 
 # Basic usage:
-exp = TuningExperiment("config_files/exp_config.json")
+exp = TuningExperiment(exp_config_file="config_files/exp_config.json")
 exp.run()
 
 # Optional callbacks:
 from Mycallbacks import Mycallbacks1, Mycallbacks2 #(It is recommended to extend the BaseCallbacks class of RL4CC)
-exp = TuningExperiment("config_files/exp_config.json")
+exp = TuningExperiment(exp_config_file="config_files/exp_config.json")
 callbacks = [Mycallbacks, Mycallbacks2]
 exp.run(callbacks=callbacks)
 ```
 
 ## The RL4CC Logger
 
-The RL4CC `Logger` can be configured to print messages with different 
-verbosity levels, using either the `sys.stdout`/`err` streams or 
-suitably-defined file streams according to the information specified in the 
-[`exp_config.json` file](config_files/README.md#configure-experiment-logging).
+The RL4CC `Logger` can be configured to print messages with different verbosity
+levels, using either the `sys.stdout`/`err` streams or suitably-defined file
+streams according to the information specified in the [`exp_config`
+config](config_files/README.md#configure-experiment-logging).
 
 The format of logged messages is:
 
@@ -246,13 +264,13 @@ where:
 - `TIME` is given by `datetime.datetime.now()`.
 - The `LOGGER_NAME` is provided as parameter in the `Logger` constructor 
 (default: `RL4CCLogger`).
-- The message `LEVEL` is 0 for warnings and errors (which are always printed 
-regardless the verbosity level specified by the user), while it is specified 
-as parameter when calling the `Logger.log()` method for generic messages. As 
-mentioned in the 
-[`exp_config.json` file](config_files/README.md#configure-experiment-logging), 
-generic messages are printed only if the corresponding `LEVEL` is lower than 
-the verbosity imposed by the user.
+- The message `LEVEL` is 0 for warnings and errors (which are always printed
+  regardless the verbosity level specified by the user), while it is specified
+  as parameter when calling the `Logger.log()` method for generic messages. As
+  mentioned in the [`exp_config`
+  config](config_files/README.md#configure-experiment-logging), generic messages
+  are printed only if the corresponding `LEVEL` is lower than the verbosity
+  imposed by the user.
 - The `MESSAGE_TYPE` is `INFO` when calling `Logger.log()`, `WARNING` when 
 calling `Logger.warn()` and `ERROR` when calling `Logger.error()`.
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ config](config_files/README.md#experiment-configuration) (or in `~/ray_results`
 if nothing is provided). These include:
 
 - `complete_config`: a directory containing the configuration (`exp_config`,
-  `envconfig` and `ray_config`) used to define the experiment, saved as JSON
+  `env_config` and `ray_config`) used to define the experiment, saved as JSON
   files.
 > [!NOTE]
 > Two important notes:
->   - The configuration is saved as files even if you pass to RL4CC dictionaries
->     and not JSON files.
+>   - JSON files are saved here, regardless the fact that the user passed the
+>     configuration(s) as file(s) or as `dict` object(s).
 >   - While `env_config.json` and `exp_config.json` are simply copied from the
 >     user-defined configurations, the `ray_config.json` file reported here
 >     includes also the default values assigned to keys that were not included
@@ -274,7 +274,8 @@ where:
 - The `MESSAGE_TYPE` is `INFO` when calling `Logger.log()`, `WARNING` when 
 calling `Logger.warn()` and `ERROR` when calling `Logger.error()`.
 
-:warning::warning::warning: file streams TBA
+> [!WARNING]
+> file streams TBA
 
 ## How to add new RL methods
 

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -1,9 +1,20 @@
-## Expected structure of the configuration files
+## Expected structure of the configuration
 
-Each experiment is controlled by one base configuration file, in `JSON` 
-format, denoted in the following as `exp_config.json`. It includes information 
-about the experiment to run (e.g., the name of the algorithm to use, 
-whether to start from an existing checkpoint, etc.). 
+Each experiment is controlled by a base configuration, a dictionary, called
+`exp_config`. It contains information about the experiment to run (e.g., the
+name of the algorithm to use, whether to start from an existing checkpoint,
+etc.).
+
+RL4CC experiment classes (`BaseExperiment`, `TrainingExperiment` and
+`TuningExperiment`) can read the `exp_config` in two ways:
+
+1. From a JSON file (like `exp_config.json`) using the `exp_config_file`
+   parameter,
+2. From a dictionary using the `exp_config` parameter.
+
+> [!WARNING]
+> You must specify one of the two parameters and they cannot be specified at the
+> same time.
 
 If the experiment should start from scratch (i.e., no previous checkpoints 
 are available), the configuration is completed by two (or three) additional 
@@ -12,10 +23,10 @@ and, possibly, the `Tuner` configuration.
 
 The corresponding structure is detailed in the following.
 
-### `Environment` configuration file
+### `Environment` configuration
 
-The `env_config.json` file includes **four** mandatory parameters, which 
-are related to Environment name and the simulation time management within it. 
+The `env_config` must include **four** mandatory parameters, which are related
+to Environment name and the simulation time management within it.
 
 These are:
 - `env_name`: the name of the Environment, as it is registered in the 
@@ -43,10 +54,11 @@ new agent decision is taken every 10 seconds.
 **Important note:** these parameters should be set even in a non-episodic 
 environment. Use `max_time` to represent the Environment horizon.
 
-### Ray `Algorithm` configuration file
+### Ray `Algorithm` configuration
 
-The `ray_config.json` file includes parameters related to the definition 
-of a Ray [`AlgorithmConfig`](https://docs.ray.io/en/latest/rllib/rllib-training.html#configuring-rllib-algorithms) object. 
+The `ray_config` file must include parameters related to the definition of a Ray
+[`AlgorithmConfig`](https://docs.ray.io/en/latest/rllib/rllib-training.html#configuring-rllib-algorithms)
+object.
 
 Parameters should be grouped in sub-dictionaries following the callbacks 
 structure of `AlgorithmConfig`. The most relevant families of parameters are:
@@ -89,16 +101,16 @@ the two approaches cannot be mixed.
 
 :warning::warning::warning: **Important note:** there are few elements that, 
 differently from what is explained in the Ray documentation **should not** be 
-managed through `ray_config.json`. These are:
+managed through `ray_config`. These are:
 - `env` and `env_config`, from the `environment` parameters group;
 - `evaluation_interval`, from the `evaluation` parameters group;
 - `logdir`, from the `logger_config` dictionary in the `debugging` parameters 
 group.
 
-In particular, `env` and `env_config` are indirectly controlled through the 
-[`env_config.json`](#environment-configuration-file) file, while 
-`evaluation_interval` and `logdir` are set from the 
-[experiment configuration file](#experiment-configuration-file).
+In particular, `env` and `env_config` are indirectly controlled through the
+[`env_config`](#environment-configuration) configuration, while
+`evaluation_interval` and `logdir` are set from the [experiment configuration
+file](#experiment-configuration).
 
 **Additional note:** in the `callbacks` section, the `callbacks_class` 
 parameter should correspond to the path to the callbacks class as it would 
@@ -277,9 +289,10 @@ experiment without specifying the path to a `tune_config.json` file in the
 `exp_config.json` file, the execution will be interrupted prompting the user to 
 provide them.
 
-### Experiment configuration file
+### Experiment configuration
 
-The `exp_config.json` includes parameters related to the training and/or  hyperparameter tuning experiment (e.g., the algorithm to use, the stopping 
+The `exp_config` includes parameters related to the training and/or
+hyperparameter tuning experiment (e.g., the algorithm to use, the stopping
 criteria, etc.).
 
 The **mandatory parameters** vary depending on whether a simple training or 
@@ -310,11 +323,14 @@ Environment or the Ray Algorithm configuration files are neglected.
   - :warning::warning::warning: in the case of `TuningExperiment`s, the 
   path is the path to the general tuning experiment outputs folder within 
   `logdir`, not the path to a specific checkpoint directory.
-- `env_config_file`: path to the `env_config.json` file described 
-[above](#environment-configuration-file). This parameter is **mandatory** if 
-no previous checkpoint is provided.
-- `ray_config_file`: path to the `ray_config.json` file described 
-[above](#ray-algorithm-configuration-file).
+- `env_config_file`: path to the `env_config.json` file described
+  [above](#environment-configuration).
+- `env_config`: dictionary containing the environment configuration described
+  [above](#environment-configuration).
+- `ray_config_file`: path to the `ray_config.json` file described
+  [above](#ray-algorithm-configuration).
+- `ray_config`: dictionary containing the Ray configuration described
+  [above](#ray-algorithm-configuration).
 - `tune_config_file`: path to the `tune_config.json` file described 
 [above](#tuner-configuration-file). This parameter is **mandatory** if 
 no previous checkpoint is provided.
@@ -325,6 +341,11 @@ end of the training loop, even if no parameter is provided here.
 should be saved. **Important note:** one checkpoint is always saved at the 
 end of the training loop, even if no parameter is provided here.
 - `plot_interval`: TBA
+
+> [!WARNING]
+> If no previously checkpoint is provided, you **must** specify either
+> `env_config_file` or `env_config` but not both. The same applies to
+> `ray_config_file` and `ray_config`.
 
 Example (for a training experiment): 
 

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -171,33 +171,33 @@ information:
 Examples are reported for both the PPO and DQN algorithms in the the 
 corresponding template files.
 
-:warning::warning::warning: The framework the model is based on **must** match 
-the framework passed in the ray_config.json file, otherwise this will result 
-in runtime errors.
+> [!WARNING]
+> The framework the model is based on **must** match the framework passed in the
+> `ray_config`, otherwise this will result in runtime errors.
 
 ### Configure hyperparameter tuning
 
 To run hyperparameter tuning, the user should: 
-1. provide a tune_config.json file (including parameters related to the 
-configuration of the `Tuner` object), and
-2. adapt the ray_config.json file to properly define the search space.
+
+1. provide a `tune_config` (including parameters related to the configuration of
+   the `Tuner` object), and
+2. adapt the `ray_config` file to properly define the search space.
 
 Details are provided in the following.
 
-#### `Tuner` configuration file
+#### `Tuner` configuration
 
-The `tune_config.json` file includes **three** mandatory parameter, which 
-are related to the number of tune trials and the identification of the 
-best result. 
+The `tune_config` must include **three** mandatory parameter, which are related
+to the number of tune trials and the identification of the best result.
 
 These are:
-- `num_tune_trials`: the number of tuning trials (possibly run in parallel, 
-if the cluster resources are enough to do so). These trials will sample from 
-the Tune search space (defined according to the elements in the 
-ray_config.json file, as detailed in 
-[the next section](#configuring-the-search-space-for-parameters)). **Note 
-that,** if the `num_tune_trials` parameter is -1, (virtually) 
-infinite samples are generated until a stopping condition is met.
+
+- `num_tune_trials`: the number of tuning trials (possibly run in parallel, if
+  the cluster resources are enough to do so). These trials will sample from the
+  Tune search space (defined according to the elements in the `ray_config`, as
+  detailed in [the next section](#configuring-the-search-space-for-parameters)).
+  **Note that,** if the `num_tune_trials` parameter is -1, (virtually) infinite
+  samples are generated until a stopping condition is met.
 - `metric`: the metric used to evaluate the performance of a given set of 
 parameters in a trial.
 - `mode`: the mode on which the values returned by the metric are evaluated. 
@@ -217,13 +217,15 @@ checkpoint. These include:
   - the `resume_unfinished` field, related to the possibilty of resuming an 
   experiment left in the `RUNNING` state. By default, it is `True`.
 
-**Note**: currently, only the `HyperOpt` search algorithm and the 
-`ASHAScheduler` are implemented.
+> [!NOTE]
+> Currently, only the `HyperOpt` search algorithm and the `ASHAScheduler` are
+> implemented.
 
-:warning::warning::warning: **Note:** experiments left in the `TERMINATED` 
-state cannot be resumed: you have to start a new experiment from scratch if 
-you want to test new parameters or change other configuration terms as 
-the metric, mode or number of tune trials.
+> [!WARNING]
+> **Note:** experiments left in the `TERMINATED` 
+state cannot be resumed: you have to start a new experiment from scratch if you
+want to test new parameters or change other configuration terms as the metric,
+mode or number of tune trials.
 
 Sample configuration:
 
@@ -250,17 +252,16 @@ Sample configuration:
 
 #### Configuring the `search space` for parameters
 
-The Tuner configurations file `tune_config.json` described in the section 
-[above](#tuner-configuration-file) is responsible for the behaviour of the 
-`Tuner` and how it handles the `Trials` running in parallel. However, 
-to actually fine-tune algorithm parameters, the user should define the 
-search space by suitably adapting the `ray_config.json` file.
+The Tuner configuration `tune_config` described in the section
+[above](#tuner-configuration) is responsible for the behaviour of the `Tuner`
+and how it handles the `Trials` running in parallel. However, to actually
+fine-tune algorithm parameters, the user should define the search space by
+suitably adapting the `ray_config`.
 
-This can be simply done by providing the values of each parameter to be 
-tuned as a `tune.**search_space` string. 
-For example, if the learning rate for the PPO algorithm is to be tuned, locate 
-the corresponding parameter (`lr`, in the `training` section) in the 
-ray_config.json file and set it as:
+This can be simply done by providing the values of each parameter to be tuned as
+a `tune.**search_space` string.  For example, if the learning rate for the PPO
+algorithm is to be tuned, locate the corresponding parameter (`lr`, in the
+`training` section) in the `ray_config` file and set it as:
 
 ```
 "training": {
@@ -274,20 +275,19 @@ ray_config.json file and set it as:
 }
 ```
 
-In the above example, the `Tuner` will sample `num_tune_trials` (present in 
-the `tune_config.json` file) trials; each trial will run for the specified
-number of `max_iterations` (present in the `exp_config.json` file, as 
-discussed in [the following](#experiment-configuration-file)), considering a 
-different `lr` value sampled from the `loguniform` distribution 
-over the range of `(1e-4, 1e-1)`.
+In the above example, the `Tuner` will sample `num_tune_trials` (present in the
+`tune_config` file) trials; each trial will run for the specified number of
+`max_iterations` (present in the `exp_config` file, as discussed in [the
+following](#experiment-configuration)), considering a different `lr` value
+sampled from the `loguniform` distribution over the range of `(1e-4, 1e-1)`.
 
 For more about tune search spaces see 
 [the relative documentation](https://docs.ray.io/en/latest/tune/api/search_space.html).
 
-:warning::warning::warning: **Note**: When the user tries to start a new tuning 
-experiment without specifying the path to a `tune_config.json` file in the 
-`exp_config.json` file, the execution will be interrupted prompting the user to 
-provide them.
+> [!WARNING]
+> When the user tries to start a new tuning experiment without specifying the
+> path to a `tune_config.json` file in the `exp_config.json` file, the execution
+> will be interrupted prompting the user to provide them.
 
 ### Experiment configuration
 
@@ -320,9 +320,10 @@ directory if no value is provided here is `~/ray_results`.
 - `from_checkpoint`: path to the directory where the checkpoint to be 
 restored is saved. If this is provided, further information related to the 
 Environment or the Ray Algorithm configuration files are neglected.
-  - :warning::warning::warning: in the case of `TuningExperiment`s, the 
-  path is the path to the general tuning experiment outputs folder within 
-  `logdir`, not the path to a specific checkpoint directory.
+    > [!WARNING]
+    > In the case of `TuningExperiment`s, the path is the path to the general
+    > tuning experiment outputs folder within `logdir`, not the path to a
+    > specific checkpoint directory.
 - `env_config_file`: path to the `env_config.json` file described
   [above](#environment-configuration).
 - `env_config`: dictionary containing the environment configuration described
@@ -331,9 +332,10 @@ Environment or the Ray Algorithm configuration files are neglected.
   [above](#ray-algorithm-configuration).
 - `ray_config`: dictionary containing the Ray configuration described
   [above](#ray-algorithm-configuration).
-- `tune_config_file`: path to the `tune_config.json` file described 
-[above](#tuner-configuration-file). This parameter is **mandatory** if 
-no previous checkpoint is provided.
+- `tune_config_file`: path to the `tune_config.json` file described
+  [above](#tuner-configuration).
+- `tune_config`: dictionary containing the tuner configuration described
+  [above](#tuner-configuration).
 - `evaluation_interval`: after how many iterations the evaluation should be 
 performed. **Important note:** one evaluation step is always performed at the 
 end of the training loop, even if no parameter is provided here.
@@ -345,7 +347,8 @@ end of the training loop, even if no parameter is provided here.
 > [!WARNING]
 > If no previously checkpoint is provided, you **must** specify either
 > `env_config_file` or `env_config` but not both. The same applies to
-> `ray_config_file` and `ray_config`.
+> Ray config (`ray_config_file` and `ray_config`) and tuner configuration
+> (`tune_config_file` and `tune_config`),
 
 Example (for a training experiment): 
 

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -74,48 +74,60 @@ rate) and algorithm-specific properties.
 A more comprehensive list is provided in 
 [the Ray documentation](https://docs.ray.io/en/latest/rllib/rllib-training.html#configuring-rllib-algorithms).
 
-:warning::warning::warning: **Important note:** to simplify the management of 
-some parameters related to the experience sampling and training, RL4CC offers 
-the possibility of setting higher-level *suggested* keywords insted of 
-using directly the ones defined in Ray. These are:
-- In the `rollouts` section:
-  - `duration_unit`: it can take the value `episodes`, if rollout workers 
-  should collect entire episodes during the experience sampling phase, or 
-  `timesteps`, if episodes can be truncated during the experience sampling;
-  - `duration_per_worker`: how many episodes/steps should be collected by 
-  each rollout worker.
-- In the `training` section:
-  - `batch_size`: dimension of each batch extracted from the collected 
-  experience (or the replay buffer, if defined) during the training phase;
-  - `num_train_batches`: how many batches should be trained in each iteration.
-- in the `resources` section:
-  - `num_gpus_master`: number of GPUs assigned to the master node;
-  - `num_cpus_master`: number of CPUs assigned to the master node.
-- in the `evaluation` section:
-  - `evaluation_duration_per_worker`: how many episodes/steps should be collected by each evaluation worker.
+> [!WARNING]
+> To simplify the management of some parameters related to the experience
+> sampling and training, RL4CC offers the possibility of setting higher-level
+> *suggested* keywords instead of directly using the ones defined in Ray. These
+> are:
+>
+> - In the `rollouts` section:
+>   - `duration_unit`: it can take the value `episodes`, if rollout workers
+>     should collect entire episodes during the experience sampling phase, or
+>     `timesteps`, if episodes can be truncated during the experience sampling;
+>
+>   - `duration_per_worker`: how many episodes/steps should be collected by each
+>     rollout worker.
+>
+> - In the `training` section:
+>   - `batch_size`: dimension of each batch extracted from the collected
+>     experience (or the replay buffer, if defined) during the training phase;
+>
+>   - `num_train_batches`: how many batches should be trained in each iteration.
+>
+> - in the `resources` section:
+>   - `num_gpus_master`: number of GPUs assigned to the master node;
+>
+>   - `num_cpus_master`: number of CPUs assigned to the master node.
+>
+> - in the `evaluation` section:
+>   - `evaluation_duration_per_worker`: how many episodes/steps should be
+>     collected by each evaluation worker.
+>
+> These keywords mask a lower-level management performed by Ray, where different
+> algorithms use different parameters to control the same elements. An
+> **expert** user is free to set directly the Ray *protected* keywords, but the
+> two approaches cannot be mixed.
 
-These keywords mask a lower-level management performed by Ray, where different 
-algorithms use different parameters to control the same elements. An 
-**expert** user is free to set directly the Ray *protected* keywords, but 
-the two approaches cannot be mixed.
+> [!WARNING]
+> There are few elements that, differently from what is explained in the Ray
+> documentation **should not** be managed through `ray_config`. These are:
+>
+> - `env` and `env_config`, from the `environment` parameters group;
+>
+> - `evaluation_interval`, from the `evaluation` parameters group;
+>
+> - `logdir`, from the `logger_config` dictionary in the `debugging` parameters
+>   group.
+>
+> In particular, `env` and `env_config` are indirectly controlled through the
+> [`env_config`](#environment-configuration) configuration, while
+> `evaluation_interval` and `logdir` are set from the [experiment configuration
+> file](#experiment-configuration).
 
-:warning::warning::warning: **Important note:** there are few elements that, 
-differently from what is explained in the Ray documentation **should not** be 
-managed through `ray_config`. These are:
-- `env` and `env_config`, from the `environment` parameters group;
-- `evaluation_interval`, from the `evaluation` parameters group;
-- `logdir`, from the `logger_config` dictionary in the `debugging` parameters 
-group.
-
-In particular, `env` and `env_config` are indirectly controlled through the
-[`env_config`](#environment-configuration) configuration, while
-`evaluation_interval` and `logdir` are set from the [experiment configuration
-file](#experiment-configuration).
-
-**Additional note:** in the `callbacks` section, the `callbacks_class` 
-parameter should correspond to the path to the callbacks class as it would 
-be reported while importing the module (e.g., 
-`"callbacks.base_callbacks.BaseCallbacks"`).
+> [!NOTE]
+> In the `callbacks` section, the `callbacks_class` parameter should correspond
+> to the path to the callbacks class as it would be reported while importing the
+> module (e.g., `"callbacks.base_callbacks.BaseCallbacks"`).
 
 Sample `ray_config.json` files for [PPO](ray_config_ppo.json.template) and 
 [DQN](ray_config_dqn.json.template) are provided.

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -24,15 +24,25 @@ import os
 
 
 class BaseExperiment(ABC):
-  def __init__(
-      self, exp_config_file: str, logger: Logger = Logger(name = "RL4CC")
-    ):
-    # load experiment configuration file
-    self.exp_config = load_config_file(exp_config_file)
-    if self.exp_config is None:
-      raise RuntimeError(
-        f"ERROR: file `{exp_config_file}` not found or invalid"
-      )
+  def __init__(self,
+               exp_config_file: str = None,
+               exp_config: dict = None,
+               logger: Logger = Logger(name = "RL4CC")):
+    # Handle exp_config_file and exp_config, they cannot be both None or both
+    # set.
+    if exp_config_file is None and exp_config is None:
+      raise RuntimeError("ERROR: exp_config_file and exp_config cannot both be None")
+    if exp_config_file is not None and exp_config is not None:
+      raise RuntimeError("ERROR: exp_config_file and exp_config cannot both be defined")
+
+    # Set self.exp_config.
+    if exp_config_file is not None:
+      self.exp_config = load_config_file(exp_config_file)
+      if self.exp_config is None:
+        raise RuntimeError(f"ERROR: file {exp_config_file!r} not found or invalid")
+    else:
+      self.exp_config = exp_config
+
     # initialize logger
     self.logger = logger
     if "logger" in self.exp_config:

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from utilities.common import load_config_file, write_config_file, not_defined
+from utilities.common import load_config_file, write_config_file, not_defined, defined
 from utilities.logger import Logger
 
 from abc import ABC, abstractmethod
@@ -75,21 +75,47 @@ class BaseExperiment(ABC):
       self.ray_config = None
       self.logdir = None
       # ...environment and ray configurations (if provided) are ignored
-      keys = ["env_config_file", "ray_config_file", "logdir"]
+      keys = ["env_config_file",
+              "env_config",
+              "ray_config_file",
+              "ray_config",
+              "logdir"]
       for key in keys:
         if key in self.exp_config:
           self.logger.warn(
-            f"previous checkpoint provided; `{key}` is ignored"
+            f"previous checkpoint provided; {key!r} is ignored"
           )
     # otherwise, the environment configuration file is mandatory
     else:
-      if not_defined("env_config_file", self.exp_config):
-        raise KeyError(
-          "ERROR: provide `env_config_file` if no previous checkpoint is given"
-        )
+      # Load the env_config. The user can specify the env_config via the
+      # env_config_file parameter or directly via the env_config parameter.
+      if (not_defined("env_config_file", self.exp_config)
+          and not_defined("env_config", self.exp_config)):
+        raise KeyError("ERROR: provide 'env_config_file' or 'env_config' if no previous checkpoint is given")
+      if (defined("env_config_file", self.exp_config)
+          and defined("env_config", self.exp_config)):
+        raise KeyError("ERROR: 'env_config_file' or 'env_config' cannot be both set!")
+
+      if defined("env_config_file", self.exp_config):
+        self.env_config = load_config_file(self.exp_config["env_config_file"])
+      else:
+        self.env_config = self.exp_config["env_config"]
+
+      # Load the ray_config. The user can specify the ray_config via the
+      # ray_config_file parameter or directly via the ray_config parameter.
+      if (not_defined("ray_config_file", self.exp_config)
+          and not_defined("ray_config", self.exp_config)):
+        raise KeyError("ERROR: provide 'ray_config_file' or 'ray_config' if no previous checkpoint is given")
+      if (defined("ray_config_file", self.exp_config)
+          and defined("ray_config", self.exp_config)):
+        raise KeyError("ERROR: 'ray_config_file' or 'ray_config' cannot be both set!")
+
+      if defined("ray_config_file", self.exp_config):
+        self.ray_config = load_config_file(self.exp_config["ray_config_file"])
+      else:
+        self.ray_config = self.exp_config["ray_config"]
+
       self.checkpoint_path = None
-      self.env_config = load_config_file(self.exp_config["env_config_file"])
-      self.ray_config = load_config_file(self.exp_config.get("ray_config_file"))
       # base output directory
       base_logdir = self.exp_config.get(
         "logdir"#, os.path.expanduser("~/ray_results"))

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -24,10 +24,11 @@ import os
 
 
 class TrainingExperiment(BaseExperiment):
-  def __init__(
-      self, exp_config_file: str, logger: Logger = Logger(name = "RL4CC")
-    ):
-    super().__init__(exp_config_file, logger)
+  def __init__(self,
+               exp_config_file: str = None,
+               exp_config: dict = None,
+               logger: Logger = Logger(name = "RL4CC")):
+    super().__init__(exp_config_file, exp_config, logger)
   
   def validate_experiment_configuration(self):
     super().validate_experiment_configuration()

--- a/experiments/tune.py
+++ b/experiments/tune.py
@@ -26,10 +26,11 @@ import os
 
 
 class TuningExperiment(BaseExperiment):
-  def __init__(
-      self, exp_config_file: str, logger: Logger = Logger(name = "RL4CC")
-    ):
-    super().__init__(exp_config_file, logger)
+  def __init__(self,
+               exp_config_file: str = None,
+               exp_config: dict = None
+               logger: Logger = Logger(name = "RL4CC")):
+    super().__init__(exp_config_file, exp_config, logger)
   
   def validate_experiment_configuration(self):
     super().validate_experiment_configuration()

--- a/experiments/tune.py
+++ b/experiments/tune.py
@@ -34,16 +34,30 @@ class TuningExperiment(BaseExperiment):
   
   def validate_experiment_configuration(self):
     super().validate_experiment_configuration()
-    # the tuning configuration file is mandatory
-    if not_defined("tune_config_file", self.exp_config):
-      if not_defined("from_checkpoint", self.exp_config): 
-        raise KeyError(
-          "ERROR: provide `tune_config_file` or a previous checkpoint"
-        )
+
+    # If a checkpoint is provided, it is not necessary to load tune_config.
+    if (defined("from_checkpoint", self.exp_config)
+        and (defined("tune_config_file", self.exp_config)
+             or defined("tune_config", self.exp_config))):
+      logger.warn("'tune_config_file' and 'tune_config' ignored because checkpoint is provided")
+    if defined("from_checkpoint", self.exp_config):
       self.tune_config = None
+      return
+
+    # Load the tune_config. The user can specify the tune_config via the
+    # tune_config_file parameter or directly via the tune_config parameter.
+    if (not_defined("tune_config_file", self.exp_config)
+        and not_defined("tune_config", self.exp_config)):
+      raise KeyError("ERROR: provide 'tune_config_file' or 'tune_config' if no previous checkpoint is given")
+    if (defined("tune_config_file", self.exp_config)
+        and defined("tune_config", self.exp_config)):
+      raise KeyError("ERROR: 'tune_config_file' or 'tune_config' cannot be both set!")
+
+    if defined("tune_config_file", self.exp_config):
+      self.tune_config = load_config_file(self.exp_config["env_config_file"])
     else:
-      self.tune_config = load_config_file(self.exp_config["tune_config_file"])
-  
+        self.tune_config = self.exp_config["tune_config"]
+
   def define_checkpoint_config(self):
     """
     Initialize the dictionary storing all configuration parameters related 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -23,7 +23,7 @@ def not_defined(param: str, params_dict: dict) -> bool:
   """
   Return True if the given parameter is not set in a parameters dictionary
   """
-  return (param not in params_dict) or (params_dict[param] is None)
+  return not defined(param, params_dict)
 
 def defined(param: str, params_dict: dict) -> bool:
   """

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -25,6 +25,12 @@ def not_defined(param: str, params_dict: dict) -> bool:
   """
   return (param not in params_dict) or (params_dict[param] is None)
 
+def defined(param: str, params_dict: dict) -> bool:
+  """
+  Return True if the given parameter is set in a parameters dictionary.
+  """
+  return param in params_dict and params_dict[param] is not None
+
 def load_config_file(filename: str) -> dict:
   """
   Load the configuration file whose name is provided as parameter 


### PR DESCRIPTION
This PR implements the feature discussed in #10.

To test this feature, you can download the attached sample project that calls TrainingExperiment with different combinations of exp_config, exp_config_file (and env_config and ray_config). You need to have RL4CC installed (and the `test-ep-10` branch) in the RL4CC directory of the example project. To run the tests, do `python main.py`.

Project: [test-ep-10.zip](https://github.com/user-attachments/files/15561196/test-ep-10.zip)

Closes #10.

~~Edit: I forgot to document the feature. I'll add a new commit in the next few hours.~~ Done.