### PR TITLE
Use custom JSON encoder for NumPy types

### DIFF
--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 from utilities.common import load_config_file, write_config_file
 from utilities.common import not_defined, defined
+from utilities.common import NumpyEncoder
 from utilities.logger import Logger
 
 from abc import ABC, abstractmethod
@@ -66,7 +67,7 @@ class BaseExperiment(ABC):
     )
     # stopping criteria
     self.define_stopping_criteria()
-  
+
   def validate_experiment_configuration(self):
     # the algorithm name must be provided
     if not_defined("algorithm", self.exp_config):
@@ -151,10 +152,10 @@ class BaseExperiment(ABC):
       os.path.abspath(base_logdir), f"{algo}_{env_name}_{now}"
     )
     os.makedirs(self.logdir, exist_ok=True)
-  
+
   def define_checkpoint_config(self):
     """
-    Initialize the dictionary storing all configuration parameters related 
+    Initialize the dictionary storing all configuration parameters related
     to checkpointing
     """
     self.checkpoint_config = {
@@ -162,26 +163,26 @@ class BaseExperiment(ABC):
         "checkpoint_interval", np.inf
       )
     }
-  
+
   def write_config_files(self):
     """
-    Write the environment and experiment configuration files into the 
+    Write the environment and experiment configuration files into the
     experiment logdir
     """
     # write environment configuration file
     if self.env_config is not None:
       write_config_file(
-        json.dumps(self.env_config, indent = 2), 
-        os.path.join(self.logdir, "complete_config"), 
+        json.dumps(self.env_config, indent = 2),
+        os.path.join(self.logdir, "complete_config"),
         "env_config.json"
       )
     # write experiment configuration file
     write_config_file(
-      json.dumps(self.exp_config, indent = 2), 
-      os.path.join(self.logdir, "complete_config"), 
+      json.dumps(self.exp_config, indent = 2),
+      os.path.join(self.logdir, "complete_config"),
       "exp_config.json"
     )
-  
+
   def update_progress_file(self, key: str, value):
     """
     Update the information written in the experiment progress file
@@ -197,7 +198,7 @@ class BaseExperiment(ABC):
     # write updated file
     with open(exp_progress_file, "w") as ostream:
       ostream.write(json.dumps(exp_progress, indent = 2))
-  
+
   def update_evaluation_metrics_file(
       self, last_iter: int, evaluation_metrics: dict
     ):
@@ -220,15 +221,19 @@ class BaseExperiment(ABC):
     evaluations_dict['evaluations'].append(evaluation)
 
     with open(evaluations_file_path, 'w+') as f:
-        json.dump(evaluations_dict, f, indent=4)
-  
+      # We need to use a custom JSON encoder because the user can be added some
+      # custom properties as NumPy arrays. NumPy types need to be converted to
+      # Python types before doing the JSON dump because the default encoder
+      # doesn't support NumPy types.
+      json.dump(evaluations_dict, f, indent=4, cls=NumpyEncoder)
+
   def plot_results(self, result: dict) -> str:
     pass
 
   @abstractmethod
   def define_stopping_criteria(self, exp_config: dict):
     pass
-  
+
   @abstractmethod
   def run(self):
     pass
@@ -243,13 +248,13 @@ class BaseExperiment(ABC):
     em = {}
     items_for_loop = {}
     if (
-      "env_runners" in evaluation_metrics.keys() and 
+      "env_runners" in evaluation_metrics.keys() and
         "hist_stats" in evaluation_metrics["env_runners"].keys()
     ):
       items_for_loop = evaluation_metrics["env_runners"]["hist_stats"].items()
       em = {**evaluation_metrics["env_runners"]}
     elif (
-      "hist_stats" in evaluation_metrics.keys() and 
+      "hist_stats" in evaluation_metrics.keys() and
         len(evaluation_metrics["hist_stats"].keys()) > 0
     ):
       items_for_loop = evaluation_metrics["hist_stats"].items()

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 from typing import Tuple
 import pandas as pd
+import numpy as np
 import json
 import os
 
@@ -33,7 +34,7 @@ def defined(param: str, params_dict: dict) -> bool:
 
 def load_config_file(filename: str) -> dict:
   """
-  Load the configuration file whose name is provided as parameter 
+  Load the configuration file whose name is provided as parameter
   (if available)
   """
   config = None
@@ -44,7 +45,7 @@ def load_config_file(filename: str) -> dict:
 
 def write_config_file(jconfig: str, dirname: str, filename: str) -> str:
   """
-  Write the given configuration dictionary (in json format) into the 
+  Write the given configuration dictionary (in json format) into the
   provided directory with the given file name
   """
   os.makedirs(dirname, exist_ok = True)
@@ -55,7 +56,7 @@ def write_config_file(jconfig: str, dirname: str, filename: str) -> str:
 
 def compare_dictionaries(d1: dict, d2: dict) -> Tuple[bool, list]:
   """
-  Return True if the content of two dictionaries (possibly with nested keys) 
+  Return True if the content of two dictionaries (possibly with nested keys)
   is equal
   """
   equal = True
@@ -66,7 +67,7 @@ def compare_dictionaries(d1: dict, d2: dict) -> Tuple[bool, list]:
         e, d = compare_dictionaries(d1[key], d2[key])
         if not e:
           different_keys += d
-          equal = False 
+          equal = False
       elif isinstance(val, list) or isinstance(val, tuple):
         if any([v1 != v2 for v1, v2 in zip(val, d2[key])]):
           different_keys.append(key)
@@ -91,7 +92,7 @@ def compute_deviation(
     baseline: pd.Series, target: pd.Series
   ) -> Tuple[pd.Series, float, float, float]:
   """
-  Compute the deviation (and its minimum, maximum and average value) between 
+  Compute the deviation (and its minimum, maximum and average value) between
   a baseline and a target (increases as target becomes lower than baseline)
   """
   deviation = (baseline - target) / baseline
@@ -99,3 +100,14 @@ def compute_deviation(
   M = float(deviation.max())
   avg = float(deviation.mean())
   return deviation, m, M, avg
+
+# Thanks to: https://stackoverflow.com/a/47626762
+class NumpyEncoder(json.JSONEncoder):
+  def default(self, obj):
+    if isinstance(obj, np.ndarray):
+      return obj.tolist()
+    elif isinstance(obj, np.number):
+      return obj.item()
+
+    # Use the default JSON encoder for other types.
+    return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
This pull request fixes #17. It adds a custom JSON encoder to convert NumPy types (if any) in the object that needs to be serialized. Why add support for NumPy types? Because NumPy is widely used for experiments and also for the environment.