### PR TITLE
Implemented custom ProgressReporter to log tune status

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,14 @@ properly defined, as detailed in the corresponding
 
 ### Training experiments with plots
 
-If you want to automatically generate plots during the training, you can use the `TrainingExperimentWithPlots` class, which is a subclass of `TrainingExperiment`. This class will automatically generate plots the last iteration and a moving average of all the iterations. The plots will be saved in the `plots` directory in the `logdir` previously specified.
-In order to specify the plots to be generated, you can use the `RELEVANT_KEYS` of the callbacks: in particular, define a custom callback class (extending the `BaseCallbacksForPlots`class).
+If you want to automatically generate plots during the training, you can use the 
+`TrainingExperimentWithPlots` class, which is a subclass of `TrainingExperiment`. 
+This class will automatically generate plots the last iteration and a moving 
+average of all the iterations. The plots will be saved in the `plots` directory 
+in the `logdir` previously specified.
+In order to specify the plots to be generated, you can use the `RELEVANT_KEYS` of 
+the callbacks: in particular, define a custom callback class (extending the 
+`BaseCallbacksForPlots`class).
 As we use `custom_metrics` to save all metrics that we want to plot, you should set
 
 ```
@@ -193,7 +199,8 @@ if nothing is provided). These include:
   specified interval, a checkpoint is always saved at the end of the training
   process.
 
-- `evaluations.json`: a json file containing key "evaluations", which is an array of dictionaries with values collected
+- `evaluations.json`: a json file containing key "evaluations", which is an
+  array of dictionaries with values collected
   during the evaluation phase, which runs according to the frequency specified
   in the [`exp_config` config](config_files/README.md#experiment-configuration).
   The dictionary structure follows the one described for the progress.csv file,
@@ -247,8 +254,8 @@ algorithms:
 > user can provide a list of callbacks (classes) as parameters to the run
 > method, overwriting any previous callbacks indicated.
 
-Example when using the predefined `BaseEnvironment`, a `exp_config` given as
-file and, possibly, custom callbacks classes:
+Example when using the predefined `BaseEnvironment` and a `exp_config` given as
+file:
 
 ```
 from RL4CC.experiments.tune import TuningExperiment
@@ -256,12 +263,6 @@ from RL4CC.experiments.tune import TuningExperiment
 # Basic usage:
 exp = TuningExperiment(exp_config_file="config_files/exp_config.json")
 exp.run()
-
-# Optional callbacks:
-from Mycallbacks import Mycallbacks1, Mycallbacks2 #(It is recommended to extend the BaseCallbacks class of RL4CC)
-exp = TuningExperiment(exp_config_file="config_files/exp_config.json")
-callbacks = [Mycallbacks, Mycallbacks2]
-exp.run(callbacks=callbacks)
 ```
 
 ## The RL4CC Logger

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It includes the following components:
   [expected outputs](#expected-outputs)), instead of writing them on the 
   console. To use the provided reporter (or a similar user-defined one), 
   configure it through the `tune_config` dictionary or JSON file as explained 
-  in the [README](config_files#tune-configuration).
+  in the [README](config_files/README.md#tune-configuration).
 
 - a `Logger`, that can be used to print `INFO`, `WARNING` and `ERROR` messages
   in a standard format.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ It includes the following components:
   to define automatic hyperparameter tuning, as explained in
   the following [section](#how-to-start-hyperparameter-tuning).
 
+- a simple [`ProgressReporter`](callbacks/base_tune_progress_reporter.py) for 
+  Ray Tune, which periodically logs information related to the number of 
+  executed trials, the hardware resources usage and the optimization process 
+  on the `exp_progress.json` file (see the section on 
+  [expected outputs](#expected-outputs)), instead of writing them on the 
+  console. To use the provided reporter (or a similar user-defined one), 
+  configure it through the `tune_config` dictionary or JSON file as explained 
+  in the [README](config_files/README.md).
+
 - a `Logger`, that can be used to print `INFO`, `WARNING` and `ERROR` messages
   in a standard format.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It includes the following components:
   [expected outputs](#expected-outputs)), instead of writing them on the 
   console. To use the provided reporter (or a similar user-defined one), 
   configure it through the `tune_config` dictionary or JSON file as explained 
-  in the [README](config_files/README.md).
+  in the [README](config_files#tune-configuration).
 
 - a `Logger`, that can be used to print `INFO`, `WARNING` and `ERROR` messages
   in a standard format.

--- a/algorithms/generators/tune_config_generator.py
+++ b/algorithms/generators/tune_config_generator.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from callbacks.base_tune_progress_reporter import BaseProgressReporter
 from utilities.logger import Logger
 
 from ray.tune.search.hyperopt import HyperOptSearch
@@ -22,6 +22,7 @@ from ray.tune.schedulers import ASHAScheduler
 from ray.tune import TuneConfig
 from datetime import datetime
 from typing import Tuple
+import os
 
 
 class TuneConfigGenerator:
@@ -108,9 +109,11 @@ class TuneConfigGenerator:
     parameters
     """
     name = None
+    progress_file = None
     if storage_path is not None:
       now = datetime.now().strftime('%H-%M-%S.%f')
       name = f"tuning_experiment_output_{now}"
+      progress_file = os.path.join(storage_path, "exp_progress.json")
     # generate RunConfig
     run_config = RunConfig(
       name = name,
@@ -118,7 +121,10 @@ class TuneConfigGenerator:
       stop = stopping_criterion,
       storage_path = storage_path,
       callbacks = callbacks,
-      checkpoint_config = checkpoint_config
+      checkpoint_config = checkpoint_config,
+      progress_reporter = BaseProgressReporter(
+        progress_file = progress_file
+      )
     )
     return run_config
   

--- a/algorithms/generators/tune_config_generator.py
+++ b/algorithms/generators/tune_config_generator.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from callbacks.base_tune_progress_reporter import BaseProgressReporter
 from utilities.logger import Logger
 
+from ray.rllib.utils.serialization import deserialize_type
 from ray.tune.search.hyperopt import HyperOptSearch
 from ray.air import RunConfig, CheckpointConfig
 from ray.tune.schedulers import ASHAScheduler
@@ -102,7 +102,8 @@ class TuneConfigGenerator:
       stopping_criterion: dict,
       storage_path: str = None,
       callbacks: list = None,
-      checkpoint_config: CheckpointConfig = None
+      checkpoint_config: CheckpointConfig = None,
+      progress_reporter: dict = None
     ) -> RunConfig:
     """
     Generates a `RunConfig` object based on the provided configuration 
@@ -114,6 +115,23 @@ class TuneConfigGenerator:
       now = datetime.now().strftime('%H-%M-%S.%f')
       name = f"tuning_experiment_output_{now}"
       progress_file = os.path.join(storage_path, "exp_progress.json")
+    # define progress reporter
+    progress_reporter_param = {}
+    if progress_reporter is not None:
+      progress_reporter_obj = deserialize_type(
+        progress_reporter["progress_reporter_class"]
+      )
+      progress_reporter_config = progress_reporter.get(
+        "progress_reporter_config", {}
+      )
+      # add progress file path if required but defined as None
+      if "progress_file" in progress_reporter_config:
+        if progress_reporter_config["progress_file"] is None:
+          progress_reporter_config["progress_file"] = progress_file
+      # update parameter
+      progress_reporter_param = {
+        "progress_reporter": progress_reporter_obj(**progress_reporter_config)
+      }
     # generate RunConfig
     run_config = RunConfig(
       name = name,
@@ -122,9 +140,7 @@ class TuneConfigGenerator:
       storage_path = storage_path,
       callbacks = callbacks,
       checkpoint_config = checkpoint_config,
-      progress_reporter = BaseProgressReporter(
-        progress_file = progress_file
-      )
+      **progress_reporter_param
     )
     return run_config
   
@@ -140,6 +156,9 @@ class TuneConfigGenerator:
     Generates the `TuneConfig` and `RunConfig` objects based on the provided 
     configuration parameters
     """
+    # extract the progress reporter configuration from tune_config (if 
+    # provided)
+    progress_reporter = tune_config.pop("progress_reporter", None)
     # generate `TuneConfig`
     tune = self.generate_tune_config(tune_config)
     # generate `CheckpointConfig`
@@ -150,7 +169,8 @@ class TuneConfigGenerator:
       stopping_criterion = stopping_criterion,
       storage_path = storage_path,
       callbacks = callbacks,
-      checkpoint_config = checkpoint
+      checkpoint_config = checkpoint,
+      progress_reporter = progress_reporter
     )
     return tune, run
 

--- a/callbacks/base_tune_progress_reporter.py
+++ b/callbacks/base_tune_progress_reporter.py
@@ -15,18 +15,20 @@ limitations under the License.
 """
 from utilities.common import update_json_file
 
-from ray.tune.progress_reporter import CLIReporter
+from ray.tune.progress_reporter import TuneReporterBase
+from ray.tune.progress_reporter import _get_time_str, _get_trials_by_state
 from ray.tune.utils import unflattened_lookup
 from ray.tune.experiment.trial import Trial
 
 from typing import Dict, List, Optional, Union
+import time
 try:
   from collections.abc import Mapping
 except ImportError:
   from collections import Mapping
 
 
-class BaseProgressReporter(CLIReporter):
+class BaseProgressReporter(TuneReporterBase):
 
   def __init__(
       self,
@@ -62,8 +64,22 @@ class BaseProgressReporter(CLIReporter):
     self.progress_file = progress_file
 
   def report(self, trials: List[Trial], done: bool, *sys_info: Dict):
-    super().report(trials, done, *sys_info)
-    # add information on the current best trial to the proper file
+    #super().report(trials, done, *sys_info)
+    # get info on running time
+    current_time_str, running_for_str = _get_time_str(self._start_time, time.time())
+    update_json_file(self.progress_file, "current_time", current_time_str)
+    update_json_file(self.progress_file, "tune_running_for", running_for_str)
+    # system information (scheduling algorithm and resource usage)
+    update_json_file(self.progress_file, "sys_info", sys_info)
+    # get trials in different states
+    num_trials = len(trials)
+    trials_by_state = _get_trials_by_state(trials)
+    num_trials_strs = [
+        "{} {}".format(len(trials_by_state[state]), state)
+        for state in sorted(trials_by_state)
+    ]
+    update_json_file(self.progress_file, "trials_state", num_trials_strs)
+    # get information on the current best trial
     trial, metric = self._current_best_trial(trials)
     if trial is not None and self.progress_file is not None:
       # get metric value and trial parameters
@@ -78,3 +94,4 @@ class BaseProgressReporter(CLIReporter):
       update_json_file(self.progress_file, "best_trial_metric", metric)
       update_json_file(self.progress_file, "best_trial_value", metric_val)
       # update_json_file(self.progress_file, "best_trial_config", params)
+

--- a/callbacks/base_tune_progress_reporter.py
+++ b/callbacks/base_tune_progress_reporter.py
@@ -1,0 +1,80 @@
+"""
+Copyright 2024 Federica Filippini
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from utilities.common import update_json_file
+
+from ray.tune.progress_reporter import CLIReporter
+from ray.tune.utils import unflattened_lookup
+from ray.tune.experiment.trial import Trial
+
+from typing import Dict, List, Optional, Union
+try:
+  from collections.abc import Mapping
+except ImportError:
+  from collections import Mapping
+
+
+class BaseProgressReporter(CLIReporter):
+
+  def __init__(
+      self,
+      *,
+      metric_columns: Optional[Union[List[str], Dict[str, str]]] = None,
+      parameter_columns: Optional[Union[List[str], Dict[str, str]]] = None,
+      total_samples: Optional[int] = None,
+      max_progress_rows: int = 20,
+      max_error_rows: int = 20,
+      max_column_length: int = 20,
+      max_report_frequency: int = 5,
+      infer_limit: int = 3,
+      print_intermediate_tables: Optional[bool] = None,
+      metric: Optional[str] = None,
+      mode: Optional[str] = None,
+      sort_by_metric: bool = False,
+      progress_file: str = None
+    ):
+    super(BaseProgressReporter, self).__init__(
+      metric_columns = metric_columns,
+      parameter_columns = parameter_columns,
+      total_samples = total_samples,
+      max_progress_rows = max_progress_rows,
+      max_error_rows = max_error_rows,
+      max_column_length = max_column_length,
+      max_report_frequency = max_report_frequency,
+      infer_limit = infer_limit,
+      print_intermediate_tables = print_intermediate_tables,
+      metric = metric,
+      mode = mode,
+      sort_by_metric = sort_by_metric,
+    )
+    self.progress_file = progress_file
+
+  def report(self, trials: List[Trial], done: bool, *sys_info: Dict):
+    super().report(trials, done, *sys_info)
+    # add information on the current best trial to the proper file
+    trial, metric = self._current_best_trial(trials)
+    if trial is not None and self.progress_file is not None:
+      # get metric value and trial parameters
+      metric_val = unflattened_lookup(metric, trial.last_result, default=None)
+      config = trial.last_result.get("config", {})
+      parameter_columns = self._parameter_columns or list(config.keys())
+      if isinstance(parameter_columns, Mapping):
+        parameter_columns = parameter_columns.keys()
+      params = {p: unflattened_lookup(p, config) for p in parameter_columns}
+      # write information to the file
+      update_json_file(self.progress_file, "best_trial_id", trial.trial_id)
+      update_json_file(self.progress_file, "best_trial_metric", metric)
+      update_json_file(self.progress_file, "best_trial_value", metric_val)
+      # update_json_file(self.progress_file, "best_trial_config", params)

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -257,7 +257,7 @@ Additional (optional) parameters are:
 > mode or number of tune trials.
 
 The provided `BaseProgressReporter` extends the 
-`TuneReporterBase`(https://github.com/ray-project/ray/blob/master/python/ray/tune/progress_reporter.py) 
+[`TuneReporterBase`](https://github.com/ray-project/ray/blob/master/python/ray/tune/progress_reporter.py) 
 class, which accepts the following parameters:
 - `metric_columns`: Names of metrics to include in progress table. If this is 
   a dict, the keys should be metric names and the values should be the 

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -234,6 +234,17 @@ Additional (optional) parameters are:
     `ERRORED` state, respectively. By default, both are `False`.
   - the `resume_unfinished` field, related to the possibilty of resuming an
     experiment left in the `RUNNING` state. By default, it is `True`.
+- `progress_reporter`: the configuration of a custom `ProgressReporter`, 
+  including:
+  - `progress_reporter_class`: as for the callbacks, it should correspond
+  to the path to the progress reporter class as it would be reported while 
+  importing the module (e.g., 
+  `"callbacks.base_tune_progress_reporter.BaseProgressReporter"`).
+  - `progress_reporter_config`: a dictionary of parameters to be passed 
+  as keyword arguments to the `ProgressReporter` constructor. Note that, since 
+  the default progress reporters are not designed to ignore unwanted 
+  keyword arguments, an error will be thrown if the provided parameter is 
+  not an expected one.
 
 > [!NOTE]
 > Currently, only the `HyperOpt` search algorithm and the `ASHAScheduler` are
@@ -245,7 +256,45 @@ Additional (optional) parameters are:
 > want to test new parameters or change other configuration terms as the metric,
 > mode or number of tune trials.
 
-Sample configuration:
+The provided `BaseProgressReporter` extends the 
+`TuneReporterBase`(https://github.com/ray-project/ray/blob/master/python/ray/tune/progress_reporter.py) 
+class, which accepts the following parameters:
+- `metric_columns`: Names of metrics to include in progress table. If this is 
+  a dict, the keys should be metric names and the values should be the 
+  displayed names. If this is a list, the metric name is used directly.
+- `parameter_columns`: Names of parameters to include in progress table. If 
+  this is a dict, the keys should be parameter names and the values should be 
+  the displayed names. If this is a list, the parameter name is used directly. 
+  If empty, defaults to all available parameters.
+- `max_progress_rows`: Maximum number of rows to print in the progress table. 
+  The progress table describes the progress of each trial. Defaults to 20.
+- `max_error_rows`: Maximum number of rows to print in the error table. The 
+  error table lists the error file, if any, corresponding to each trial. 
+  Defaults to 20.
+- `max_column_length`: Maximum column length (in characters). Column headers 
+  and values longer than this will be abbreviated.
+- `max_report_frequency`: Maximum report frequency in seconds. Defaults to 5s.
+- `infer_limit`: Maximum number of metrics to automatically infer from 
+  tune results.
+- `print_intermediate_tables`: Print intermediate result tables. If `None` 
+  (default), will be set to `True` for verbosity levels above 3, otherwise 
+  `False`. If `True`, intermediate tables will be printed with experiment 
+  progress. If `False`, tables will only be printed at then end of the tuning 
+  run for verbosity levels greater than 2.
+- `metric`: Metric used to determine best current trial.
+- `mode`: One of `[min, max]`. Determines whether objective is minimizing or 
+  maximizing the metric attribute.
+- `sort_by_metric`: Sort terminated trials by metric in the intermediate 
+  table. Defaults to `False`.
+
+Moreover, it accepts an additional parameter, named `progress_file`, denoting 
+the path to the file where the experiment progress should be periodically 
+logged. You can provide either the complete path to a file of your choice or 
+`None`; in the second case, the progress file will default to 
+`exp_progress.json` (see the example below).
+
+Sample configuration (with a custom `ProgressReporter` logging on 
+`exp_progress.json`):
 
 ```
 {
@@ -264,9 +313,25 @@ Sample configuration:
       "reduction_factor": 3,
       "brackets": 1
     }
+  },
+  "progress_reporter": {
+    "progress_reporter_class": "callbacks.base_tune_progress_reporter.BaseProgressReporter",
+    "progress_reporter_config": {
+      "progress_file": null
+    }
   }
 }
 ```
+
+> [!WARNING]
+> Due to an ongoing [issue](https://github.com/ray-project/ray/issues/38202) 
+> with recent Ray versions, you must set the environment variable 
+> `RAY_AIR_NEW_OUTPUT=0` to be able to use custom `ProgressReporter`s.
+
+> [!NOTE]
+> Choose a large-enough verbosity level (i.e., greater than 0) in the 
+> experiment configuration to ensure that the `ProgressReporter` works as 
+> expected.
 
 #### Configuring the `search space` for parameters
 
@@ -339,7 +404,13 @@ Additional parameters are:
   directory if no value is provided here is `~/ray_results`.
 - `from_checkpoint`: path to the directory where the checkpoint to be
   restored is saved. If this is provided, further information related to the
-  Environment or the Ray Algorithm configuration files are neglected. > [!WARNING] > In the case of `TuningExperiment`s, the path is the path to the general > tuning experiment outputs folder within `logdir`, not the path to a > specific checkpoint directory.
+  Environment or the Ray Algorithm configuration files are neglected. 
+
+> [!WARNING] 
+> In the case of `TuningExperiment`s, the path is the path to the general 
+> tuning experiment outputs folder within `logdir`, not the path to a 
+> specific checkpoint directory.
+
 - `env_config_file`: path to the `env_config.json` file described
   [above](#environment-configuration).
 - `env_config`: dictionary containing the environment configuration described

--- a/config_files/README.md
+++ b/config_files/README.md
@@ -239,7 +239,8 @@ Additional (optional) parameters are:
 > Currently, only the `HyperOpt` search algorithm and the `ASHAScheduler` are
 > implemented.
 
-> [!WARNING] > **Note:** experiments left in the `TERMINATED`
+> [!WARNING]
+> Experiments left in the `TERMINATED`
 > state cannot be resumed: you have to start a new experiment from scratch if you
 > want to test new parameters or change other configuration terms as the metric,
 > mode or number of tune trials.

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 from utilities.common import load_config_file, write_config_file
 from utilities.common import not_defined, defined
+from utilities.common import update_json_file
 from utilities.common import NumpyEncoder
 from utilities.logger import Logger
 
@@ -189,17 +190,9 @@ class BaseExperiment(ABC):
     """
     Update the information written in the experiment progress file
     """
-    exp_progress = {}
-    exp_progress_file = os.path.join(self.logdir, "exp_progress.json")
-    # load existing content (if any)
-    if os.path.exists(exp_progress_file):
-      with open(exp_progress_file, "r") as istream:
-        exp_progress = json.load(istream)
-    # update
-    exp_progress[key] = value
-    # write updated file
-    with open(exp_progress_file, "w") as ostream:
-      ostream.write(json.dumps(exp_progress, indent = 2))
+    update_json_file(
+      os.path.join(self.logdir, "exp_progress.json"), key, value
+    )
 
   def update_evaluation_metrics_file(
       self, last_iter: int, evaluation_metrics: dict

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -111,3 +111,18 @@ class NumpyEncoder(json.JSONEncoder):
 
     # Use the default JSON encoder for other types.
     return json.JSONEncoder.default(self, obj)
+
+def update_json_file(filename: str, key: str, value):
+  """
+  Update the information written in the experiment progress file
+  """
+  json_obj = {}
+  # load existing content (if any)
+  if os.path.exists(filename):
+    with open(filename, "r") as istream:
+      json_obj = json.load(istream)
+  # update
+  json_obj[key] = value
+  # write updated file
+  with open(filename, "w") as ostream:
+    ostream.write(json.dumps(json_obj, indent = 2))


### PR DESCRIPTION
The provided `BaseProgressReporter` periodically logs the tune experiment status, hardware resources consumption and optimisation progress to exp_progress.json or any other configurable JSON file.